### PR TITLE
[WIP] Initial proposal for a Spring Boot parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>me.snowdrop</groupId>
-  <artifactId>spring-boot-bom</artifactId>
+  <artifactId>spring-boot-build</artifactId>
   <version>2.1.6-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <name>Snowdrop Spring Boot BOM</name>
-  <description>Bill Of Materials (BOM) file for Snowdrop project to facilitate usage of Spring Boot on OpenShift.</description>
-  <url>http://www.snowdrop.me</url>
 
   <issueManagement>
     <system>JIRA</system>
@@ -81,6 +77,11 @@
 
   <repositories>
     <repository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </repository>
+    <repository>
       <id>spring-snapshots</id>
       <url>https://repo.spring.io/snapshot</url>
       <snapshots>
@@ -94,6 +95,11 @@
   </repositories>
   <pluginRepositories>
     <pluginRepository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </pluginRepository>
+    <pluginRepository>
       <id>spring-snapshots</id>
       <url>https://repo.spring.io/snapshot</url>
     </pluginRepository>
@@ -102,7 +108,6 @@
       <url>https://repo.spring.io/milestone</url>
     </pluginRepository>
   </pluginRepositories>
-
 
   <profiles>
     <profile>
@@ -162,326 +167,8 @@
     </profile>
   </profiles>
 
-  <properties>
-    <!-- Other -->
-    <resteasy.version>3.7.0.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>3.1.0.Final</resteasy-spring-boot-starter.version>
-    <keycloak.version>4.8.3.Final</keycloak.version>
-    <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
-    <infinispan-starter.version>2.1.3.Final</infinispan-starter.version>
-    <amqp-10-starter.version>2.1.2</amqp-10-starter.version>
-    <narayana-starter.version>2.1.1</narayana-starter.version>
-    <cxf-spring-boot-starter-jaxrs.version>3.3.2</cxf-spring-boot-starter-jaxrs.version>
-    <vertx-spring-boot.version>0.0.3</vertx-spring-boot.version>
-
-    <!-- Spring Ecosystem -->
-    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>1.0.1.RELEASE</spring-cloud-kubernetes.version>
-
-    <!-- Overriden from Spring Boot -->
-    <hibernate.version>5.3.7.Final</hibernate.version>
-    <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
-    <infinispan.version>9.4.6.Final</infinispan.version>
-    <tomcat.version>9.0.21</tomcat.version>
-    <undertow.version>2.0.21.Final</undertow.version>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <!-- Infinispan BOM to ensure Infinispan versions are properly set. NEEDS TO BE SET BEFORE SPRING BOM. -->
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-bom</artifactId>
-        <version>${infinispan.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <!-- Spring Boot BOM: NOT SUPPORTED, just included to ensure dependencies are properly set -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <!-- ONLY the following Spring Boot Starters are supported -->
-
-      <!-- Core -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter</artifactId>
-        <version>${spring-boot.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-test</artifactId>
-        <version>${spring-boot.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-        <scope>test</scope>
-      </dependency>
-
-      <!-- HTTP runtime -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-tomcat</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-undertow</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!-- Web -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-web</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!-- Websocket -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-websocket</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!-- JAX-RS -->
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs</artifactId>
-        <version>${resteasy.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-spring-boot-starter</artifactId>
-        <version>${resteasy-spring-boot-starter.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-
-      <!-- JAX-RS with Apache CXF (UNSUPPORTED) -->
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
-        <version>${cxf-spring-boot-starter-jaxrs.version}</version>
-      </dependency>
-
-      <!-- Persistence -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-data-jpa</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-jdbc</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!--Monitoring -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-actuator</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!-- Distributed tracing with OpenTracing -->
-      <dependency>
-        <groupId>io.opentracing.contrib</groupId>
-        <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
-        <version>${opentracing-spring-jaeger-web-starter.version}</version>
-      </dependency>
-
-      <!-- Spring Cloud Kubernetes -->
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-starter-kubernetes</artifactId>
-        <version>${spring-cloud-kubernetes.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
-        <version>${spring-cloud-kubernetes.version}</version>
-      </dependency>
-
-      <!-- Cache / Data Grid -->
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-spring-boot-starter-embedded</artifactId>
-        <version>${infinispan-starter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-spring-boot-starter-remote</artifactId>
-        <version>${infinispan-starter.version}</version>
-      </dependency>
-
-      <!-- Messaging -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-activemq</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-artemis</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!-- AMQP -->
-      <dependency>
-        <groupId>org.amqphub.spring</groupId>
-        <artifactId>amqp-10-jms-spring-boot-starter</artifactId>
-        <version>${amqp-10-starter.version}</version>
-      </dependency>
-
-      <!-- Transactions -->
-      <dependency>
-        <groupId>me.snowdrop</groupId>
-        <artifactId>narayana-spring-boot-starter</artifactId>
-        <version>${narayana-starter.version}</version>
-      </dependency>
-
-      <!-- Security -->
-      <dependency>
-        <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-spring-boot-starter</artifactId>
-        <version>${keycloak.version}</version>
-      </dependency>
-
-      <!-- Validation -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-validation</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <!-- Vert.x -->
-      <dependency>
-        <groupId>dev.snowdrop</groupId>
-        <artifactId>vertx-spring-boot-starter</artifactId>
-        <version>${vertx-spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.snowdrop</groupId>
-        <artifactId>vertx-spring-boot-starter-http</artifactId>
-        <version>${vertx-spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.snowdrop</groupId>
-        <artifactId>vertx-spring-boot-starter-http-test</artifactId>
-        <version>${vertx-spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.snowdrop</groupId>
-        <artifactId>vertx-spring-boot-starter-actuator</artifactId>
-        <version>${vertx-spring-boot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.snowdrop</groupId>
-        <artifactId>vertx-spring-boot-starter-mail</artifactId>
-        <version>${vertx-spring-boot.version}</version>
-      </dependency>
-
-      <!-- End of supported starters -->
-
-
-      <!-- Needed dependencies, not directly supported, use starters instead -->
-
-      <!-- Hibernate Validator-->
-      <dependency>
-        <groupId>org.hibernate.validator</groupId>
-        <artifactId>hibernate-validator</artifactId>
-        <version>${hibernate-validator.version}</version>
-      </dependency>
-
-      <!-- Hibernate -->
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-core</artifactId>
-        <version>${hibernate.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-entitymanager</artifactId>
-        <version>${hibernate.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <!-- Tomcat -->
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-el</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-jasper</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-jdbc</artifactId>
-        <version>${tomcat.version}</version>
-      </dependency>
-
-      <!-- Undertow -->
-      <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-core</artifactId>
-        <version>${undertow.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-servlet</artifactId>
-        <version>${undertow.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-websockets-jsr</artifactId>
-        <version>${undertow.version}</version>
-      </dependency>
-
-    </dependencies>
-  </dependencyManagement>
+  <modules>
+    <module>spring-boot-bom</module>
+    <module>spring-boot-parent</module>
+  </modules>
 </project>

--- a/spring-boot-bom/pom.xml
+++ b/spring-boot-bom/pom.xml
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2017 Red Hat, Inc, and individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>me.snowdrop</groupId>
+    <artifactId>spring-boot-build</artifactId>
+    <version>2.1.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>spring-boot-bom</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Snowdrop Spring Boot BOM</name>
+  <description>Bill Of Materials (BOM) file for Snowdrop project to facilitate usage of Spring Boot on OpenShift.</description>
+  <url>http://www.snowdrop.me</url>
+
+  <properties>
+    <!-- Other -->
+    <resteasy.version>3.7.0.Final</resteasy.version>
+    <resteasy-spring-boot-starter.version>3.1.0.Final</resteasy-spring-boot-starter.version>
+    <keycloak.version>4.8.3.Final</keycloak.version>
+    <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
+    <infinispan-starter.version>2.1.3.Final</infinispan-starter.version>
+    <amqp-10-starter.version>2.1.2</amqp-10-starter.version>
+    <narayana-starter.version>2.1.1</narayana-starter.version>
+    <cxf-spring-boot-starter-jaxrs.version>3.3.2</cxf-spring-boot-starter-jaxrs.version>
+    <vertx-spring-boot.version>0.0.3</vertx-spring-boot.version>
+
+    <!-- Spring Ecosystem -->
+    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+    <spring-cloud-kubernetes.version>1.0.1.RELEASE</spring-cloud-kubernetes.version>
+
+    <!-- Overriden from Spring Boot -->
+    <hibernate.version>5.3.7.Final</hibernate.version>
+    <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
+    <infinispan.version>9.4.6.Final</infinispan.version>
+    <tomcat.version>9.0.21</tomcat.version>
+    <undertow.version>2.0.21.Final</undertow.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Infinispan BOM to ensure Infinispan versions are properly set. NEEDS TO BE SET BEFORE SPRING BOM. -->
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-bom</artifactId>
+        <version>${infinispan.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Spring Boot BOM: NOT SUPPORTED, just included to ensure dependencies are properly set -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- ONLY the following Spring Boot Starters are supported -->
+
+      <!-- Core -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- HTTP runtime -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-tomcat</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-undertow</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!-- Web -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!-- Websocket -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-websocket</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!-- JAX-RS -->
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-spring-boot-starter</artifactId>
+        <version>${resteasy-spring-boot-starter.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+
+      <!-- JAX-RS with Apache CXF (UNSUPPORTED) -->
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
+        <version>${cxf-spring-boot-starter-jaxrs.version}</version>
+      </dependency>
+
+      <!-- Persistence -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-jdbc</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!--Monitoring -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!-- Distributed tracing with OpenTracing -->
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        <version>${opentracing-spring-jaeger-web-starter.version}</version>
+      </dependency>
+
+      <!-- Spring Cloud Kubernetes -->
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-kubernetes</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+      </dependency>
+
+      <!-- Cache / Data Grid -->
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-spring-boot-starter-embedded</artifactId>
+        <version>${infinispan-starter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-spring-boot-starter-remote</artifactId>
+        <version>${infinispan-starter.version}</version>
+      </dependency>
+
+      <!-- Messaging -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-activemq</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-artemis</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!-- AMQP -->
+      <dependency>
+        <groupId>org.amqphub.spring</groupId>
+        <artifactId>amqp-10-jms-spring-boot-starter</artifactId>
+        <version>${amqp-10-starter.version}</version>
+      </dependency>
+
+      <!-- Transactions -->
+      <dependency>
+        <groupId>me.snowdrop</groupId>
+        <artifactId>narayana-spring-boot-starter</artifactId>
+        <version>${narayana-starter.version}</version>
+      </dependency>
+
+      <!-- Security -->
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-spring-boot-starter</artifactId>
+        <version>${keycloak.version}</version>
+      </dependency>
+
+      <!-- Validation -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-validation</artifactId>
+        <version>${spring-boot.version}</version>
+      </dependency>
+
+      <!-- Vert.x -->
+      <dependency>
+        <groupId>dev.snowdrop</groupId>
+        <artifactId>vertx-spring-boot-starter</artifactId>
+        <version>${vertx-spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.snowdrop</groupId>
+        <artifactId>vertx-spring-boot-starter-http</artifactId>
+        <version>${vertx-spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.snowdrop</groupId>
+        <artifactId>vertx-spring-boot-starter-http-test</artifactId>
+        <version>${vertx-spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.snowdrop</groupId>
+        <artifactId>vertx-spring-boot-starter-actuator</artifactId>
+        <version>${vertx-spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.snowdrop</groupId>
+        <artifactId>vertx-spring-boot-starter-mail</artifactId>
+        <version>${vertx-spring-boot.version}</version>
+      </dependency>
+
+      <!-- End of supported starters -->
+
+
+      <!-- Needed dependencies, not directly supported, use starters instead -->
+
+      <!-- Hibernate Validator-->
+      <dependency>
+        <groupId>org.hibernate.validator</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>${hibernate-validator.version}</version>
+      </dependency>
+
+      <!-- Hibernate -->
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-core</artifactId>
+        <version>${hibernate.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-entitymanager</artifactId>
+        <version>${hibernate.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <!-- Tomcat -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-jasper</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-jdbc</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <!-- Undertow -->
+      <dependency>
+        <groupId>io.undertow</groupId>
+        <artifactId>undertow-core</artifactId>
+        <version>${undertow.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.undertow</groupId>
+        <artifactId>undertow-servlet</artifactId>
+        <version>${undertow.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.undertow</groupId>
+        <artifactId>undertow-websockets-jsr</artifactId>
+        <version>${undertow.version}</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/spring-boot-parent/pom.xml
+++ b/spring-boot-parent/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>me.snowdrop</groupId>
+    <artifactId>spring-boot-build</artifactId>
+    <version>2.1.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>spring-boot-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <properties>
+    <fabric8-maven-plugin.version>4.1.0</fabric8-maven-plugin.version>
+    <spring-boot-maven-plugin.version>2.1.6.RELEASE</spring-boot-maven-plugin.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>me.snowdrop</groupId>
+        <artifactId>spring-boot-bom</artifactId>
+        <version>2.1.6-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>fabric8-maven-plugin</artifactId>
+          <version>${fabric8-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot-maven-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
I've put together an initial proposal for a possible Spring Boot parent addition. I've restructured the project in a following way:

- `spring-boot-build` - project base containing main repositories and release profile needed for all modules
  - `spring-boot-bom` - the original `spring-boot-bom` but now only containing dependencies and inheriting from `spring-boot-build`
  - `spring-boot-parent` - inherits from `spring-boot-build` and includes `spring-boot-bom` in its `dependencyManagement` section. For the user convenience it also includes `spring-boot-maven-plugin` and `fabric8-maven-plugin` as well as resource filtering. What plugins and configurations should be included here is up for discussion.

This should be backwards compatible with the existing users as `spring-boot-bom` coordinates did not change and only parts of it moved to its parent (`spring-boot-build`). This might, however, impede our release process in some unexpected way in case there are some hardcoded values in the scripts. Thus, I don't recommend moving ahead with this for the 2.1.10 release but start reorganisation immediately after it.