### PR TITLE
update Resteasy versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
 
   <properties>
     <!-- Other -->
-    <resteasy.version>3.7.0.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>3.1.1.Final</resteasy-spring-boot-starter.version>
+    <resteasy.version>3.9.0.Final</resteasy.version>
+    <resteasy-spring-boot-starter.version>3.2.1.Final</resteasy-spring-boot-starter.version>
     <keycloak.version>4.8.3.Final</keycloak.version>
     <opentracing-spring-jaeger-web-starter.version>2.0.3</opentracing-spring-jaeger-web-starter.version>
     <infinispan-starter.version>2.1.7.Final</infinispan-starter.version>
@@ -183,7 +183,7 @@
 
     <!-- Spring Ecosystem -->
     <spring-boot.version>2.1.10.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>1.0.1.RELEASE</spring-cloud-kubernetes.version>
+    <spring-cloud-kubernetes.version>1.0.4.RELEASE</spring-cloud-kubernetes.version>
 
     <!-- Overriden from Spring Boot -->
     <hibernate.version>5.3.14.Final</hibernate.version>


### PR DESCRIPTION
Please, could you review?
Finally for infinispan, If I understood well we use the `9.4.16.Final` upstream and downstream, right?