### PR TITLE
Align dependencies with SB 2.2.5 #80

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.1.13.RELEASE</version>
+    <version>2.2.5.RELEASE</version>
   </parent>
 
   <groupId>dev.snowdrop</groupId>
   <artifactId>snowdrop-dependencies</artifactId>
-  <version>2.1.13-SNAPSHOT</version>
+  <version>2.2.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Snowdrop Spring Boot Dependencies</name>
@@ -124,25 +124,26 @@
 
   <properties>
     <!-- Other -->
-    <resteasy.version>3.9.0.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>3.2.1.Final</resteasy-spring-boot-starter.version>
-    <keycloak.version>8.0.1</keycloak.version>
-    <opentracing-spring-jaeger-web-starter.version>2.0.3</opentracing-spring-jaeger-web-starter.version>
-    <infinispan-starter.version>2.1.7.Final</infinispan-starter.version>
-    <amqp-10-starter.version>2.1.7</amqp-10-starter.version>
-    <narayana-starter.version>2.1.1</narayana-starter.version>
+    <resteasy.version>3.9.0.Final</resteasy.version><!-- TODO upgrade before 2.2.5 release -->
+    <resteasy-spring-boot-starter.version>3.2.1.Final</resteasy-spring-boot-starter.version><!-- TODO upgrade before 2.2.5 release -->
+    <keycloak.version>9.0.0</keycloak.version>
+    <opentracing-spring-jaeger-web-starter.version>3.1.1</opentracing-spring-jaeger-web-starter.version>
+    <infinispan-starter.version>2.1.8.Final</infinispan-starter.version>
+    <amqp-10-starter.version>2.2.2</amqp-10-starter.version>
+    <narayana-starter.version>2.3.0</narayana-starter.version>
     <cxf-spring-boot-starter-jaxrs.version>3.3.4</cxf-spring-boot-starter-jaxrs.version>
-    <vertx-spring-boot.version>0.0.8</vertx-spring-boot.version>
+    <vertx-spring-boot.version>1.0.0</vertx-spring-boot.version>
     <dekorate.version>0.11.2</dekorate.version>
 
     <!-- Spring Ecosystem -->
-    <spring-boot.version>2.1.13.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>1.0.4.RELEASE</spring-cloud-kubernetes.version>
+    <spring-boot.version>2.2.5.RELEASE</spring-boot.version>
+    <spring-cloud-kubernetes.version>1.1.1.RELEASE</spring-cloud-kubernetes.version>
 
     <!-- Overriden from Spring Boot -->
-    <hibernate.version>5.3.15.Final</hibernate.version>
+    <artemis.version>2.10.1</artemis.version>
+    <hibernate.version>5.4.12.Final</hibernate.version>
     <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
-    <infinispan.version>9.4.15.Final</infinispan.version>
+    <infinispan.version>9.4.17.Final</infinispan.version>
     <tomcat.version>9.0.31</tomcat.version>
     <undertow.version>2.0.29.Final</undertow.version>
   </properties>


### PR DESCRIPTION
Align all but RestEasy (waiting for the next release) dependencies with Spring Boot 2.2.5.