### PR TITLE
Downgrade FMP to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <undertow.version>2.0.30.Final</undertow.version>
 
     <!-- Plugins -->
-    <fabric8-maven-plugin.version>4.4.1</fabric8-maven-plugin.version>
+    <fabric8-maven-plugin.version>4.1.0</fabric8-maven-plugin.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
I've been experiencing issues when testing different examples with the newer FMP. So at least until we figure out more I suggest to downgrade it to 4.1.0 (the one that used to be used before in our examples)