### PR TITLE
Updates for release 2.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,12 +130,8 @@
     <keycloak.version>9.0.3</keycloak.version>
     <narayana-starter.version>2.3.0</narayana-starter.version>
     <opentracing-spring-jaeger-web-starter.version>3.1.1</opentracing-spring-jaeger-web-starter.version>
-    <!-- resteasy 3.4.0.Final -->
-<!--    <resteasy.version>3.11.2.Final</resteasy.version>-->
-<!--    <resteasy-spring-boot-starter.version>3.4.0.Final</resteasy-spring-boot-starter.version>-->
-    <!-- resteasy 4.5.1.Final -->
-    <resteasy.version>4.5.3.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>4.5.1.Final</resteasy-spring-boot-starter.version>
+    <resteasy.version>3.11.2.Final</resteasy.version>
+    <resteasy-spring-boot-starter.version>3.4.0.Final</resteasy-spring-boot-starter.version>
     <vertx-spring-boot.version>1.0.0</vertx-spring-boot.version>
 
     <!-- Spring Ecosystem -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
 
   <properties>
     <amqp-10-starter.version>2.2.2</amqp-10-starter.version>
-    <cxf-spring-boot-starter-jaxrs.version>3.3.4</cxf-spring-boot-starter-jaxrs.version>
     <dekorate.version>0.11.4</dekorate.version>
     <infinispan-starter.version>2.2.3.Final</infinispan-starter.version>
     <keycloak.version>9.0.3</keycloak.version>
@@ -231,13 +230,6 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-spring-boot-starter</artifactId>
         <version>${resteasy-spring-boot-starter.version}</version>
-      </dependency>
-
-      <!-- JAX-RS with Apache CXF (UNSUPPORTED) -->
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
-        <version>${cxf-spring-boot-starter-jaxrs.version}</version>
       </dependency>
 
       <!-- Persistence -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,15 @@
     <cxf-spring-boot-starter-jaxrs.version>3.3.4</cxf-spring-boot-starter-jaxrs.version>
     <dekorate.version>0.11.4</dekorate.version>
     <infinispan-starter.version>2.2.3.Final</infinispan-starter.version>
-    <keycloak.version>9.0.2</keycloak.version>
+    <keycloak.version>9.0.3</keycloak.version>
     <narayana-starter.version>2.3.0</narayana-starter.version>
     <opentracing-spring-jaeger-web-starter.version>3.1.1</opentracing-spring-jaeger-web-starter.version>
-    <resteasy.version>3.9.3.SP1</resteasy.version>
-    <resteasy-spring-boot-starter.version>3.3.2.Final</resteasy-spring-boot-starter.version>
+    <!-- resteasy 3.4.0.Final -->
+<!--    <resteasy.version>3.11.2.Final</resteasy.version>-->
+<!--    <resteasy-spring-boot-starter.version>3.4.0.Final</resteasy-spring-boot-starter.version>-->
+    <!-- resteasy 4.5.1.Final -->
+    <resteasy.version>4.5.3.Final</resteasy.version>
+    <resteasy-spring-boot-starter.version>4.5.1.Final</resteasy-spring-boot-starter.version>
     <vertx-spring-boot.version>1.0.0</vertx-spring-boot.version>
 
     <!-- Spring Ecosystem -->


### PR DESCRIPTION
Update versions:
* keycloak to `9.0.3`
* resteasy to `4.5.3.Final`
* resteasy-spring-boot-starter to `4.5.1.Final`