### PR TITLE
feat: add release.yml for 2.3.2 release

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -1,0 +1,90 @@
+# JIRA Project where the release issue should be created
+issue:
+  project: ENTSBT
+
+
+# If already created, provide the issue number of the Release, otherwise keep it empty.
+# It will be used by the command create-component to link the stakeholder issues
+#key:         # SB-1484
+
+schedule:
+  # Release date scheduled. It will also be used to populate the description to be created for each Jira stakeholder: component or starter owner
+  release: 2020-09-14
+  # Due date for the component/starter owner to release their new components, QE signoff it
+  due: 2020-08-18
+  # EOL of the Snowdrop release
+  eol: 2021-09-30
+
+components:
+  # List of JIRA Projects contributing to a Snowdrop release
+  # They will be used to create a component or starter
+  - name: Hibernate / Hibernate Validator
+    issue:
+      project: EAPSUP
+    properties:
+      - hibernate
+      - hibernate-validator
+      - undertow
+
+  - name: Tomcat
+    issue:
+      project: JWS
+    properties:
+      - tomcat
+
+  - name: Keycloak
+    issue:
+      project: KEYCLOAK
+    properties:
+      - keycloak
+
+  - name: AMQP
+    issue:
+      project: ENTMQCL
+    properties:
+      - amqp-10-starter
+
+  - name: RESTEasy
+    issue:
+      project: RESTEASY
+    properties:
+      - resteasy
+      - resteasy-spring-boot-starter
+
+  - name: OpenTracing / Jaeger
+    issue:
+      project: TRACING
+    properties:
+      - opentracing-spring-jaeger-web-starter
+
+  - name: Infinispan / DataGrid
+    issue:
+      project: JDG
+    properties:
+      - infinispan
+      - infinispan-starter
+
+  - name: Narayana
+    issue:
+      project: ENTSBT
+    properties:
+      - narayana-starter
+
+  - name: Vert.X
+    issue:
+      project: ENTSBT
+    properties:
+      - vertx-spring-boot
+
+  - name: Dekorate
+    issue:
+      project: ENTSBT
+    properties:
+      - dekorate
+
+cves:
+  # Include here the CVEs tickets to be link to this JIRA ticket release
+  - key: 360
+  - key: 316
+  - key: 566
+  - key: 567

--- a/release.yml
+++ b/release.yml
@@ -1,3 +1,5 @@
+version: 2.3.2
+
 # JIRA Project where the release issue should be created
 issue:
   project: ENTSBT

--- a/release.yml
+++ b/release.yml
@@ -61,11 +61,13 @@ components:
 
   - name: Narayana starter
     jira: ENTSBT
+    product: JBTM
     properties:
       - narayana-starter
 
   - name: Vert.X starter
     jira: ENTSBT
+    product: ENTVTX
     properties:
       - vertx-spring-boot
 

--- a/release.yml
+++ b/release.yml
@@ -69,6 +69,11 @@ components:
     properties:
       - vertx-spring-boot
 
+  - name: Spring Cloud Kubernetes
+    jira: ENTSBT
+    properties:
+      - spring-cloud-kubernetes
+
   - name: Dekorate
     jira: ENTSBT
     properties:

--- a/release.yml
+++ b/release.yml
@@ -21,66 +21,56 @@ components:
   # List of JIRA Projects contributing to a Snowdrop release
   # They will be used to create a component or starter
   - name: Hibernate / Hibernate Validator / Undertow
-    issue:
-      project: EAPSUP
+    jira: EAPSUP
     properties:
       - hibernate
       - hibernate-validator
       - undertow
 
   - name: Tomcat
-    issue:
-      project: JWS
+    jira: JWS
     properties:
       - tomcat
 
   - name: Keycloak
-    issue:
-      project: KEYCLOAK
+    jira: KEYCLOAK
     properties:
       - keycloak
 
   - name: AMQP
-    issue:
-      project: ENTMQCL
+    jira: ENTMQCL
     properties:
       - amqp-10-starter
 
   - name: RESTEasy
-    issue:
-      project: RESTEASY
+    jira: RESTEASY
     properties:
       - resteasy
       - resteasy-spring-boot-starter
 
   - name: OpenTracing / Jaeger
-    issue:
-      project: TRACING
+    jira: TRACING
     properties:
       - opentracing-spring-jaeger-web-starter
 
   - name: Infinispan / DataGrid
-    issue:
-      project: JDG
+    jira: JDG
     properties:
       - infinispan
       - infinispan-starter
 
-  - name: Narayana
-    issue:
-      project: ENTSBT
+  - name: Narayana starter
+    jira: ENTSBT
     properties:
       - narayana-starter
 
-  - name: Vert.X
-    issue:
-      project: ENTSBT
+  - name: Vert.X starter
+    jira: ENTSBT
     properties:
       - vertx-spring-boot
 
   - name: Dekorate
-    issue:
-      project: ENTSBT
+    jira: ENTSBT
     properties:
       - dekorate
 

--- a/release.yml
+++ b/release.yml
@@ -65,7 +65,7 @@ components:
     properties:
       - narayana-starter
 
-  - name: Vert.X starter
+  - name: Vert.x starter
     jira: ENTSBT
     product: ENTVTX
     properties:

--- a/release.yml
+++ b/release.yml
@@ -20,7 +20,7 @@ schedule:
 components:
   # List of JIRA Projects contributing to a Snowdrop release
   # They will be used to create a component or starter
-  - name: Hibernate / Hibernate Validator
+  - name: Hibernate / Hibernate Validator / Undertow
     issue:
       project: EAPSUP
     properties:


### PR DESCRIPTION
Fixes #115

This file is meant to record the components that are needed for a given release as well as timeline information. Each component definition will be used to create a JIRA ticket to inform stakeholders that we're planning on releasing a new Spring Boot version and that action should be taken by validating the associated list of artifacts on the specified Spring Boot release. 

The association between component and artifacts is done via the component's associated properties so we need to make sure that these properties are correct.

Similarly, we need to make sure that the proper JIRA project is used to create the associated tickets.