### PR TITLE
chore: updated the circleci tests to use the correct branches for release 2.4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           parent_version=$(mvn -s .circleci/settings.xml -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
 
           pushd /tmp
-          git clone --single-branch -b 2.3.x https://github.com/snowdrop/testsuite.git
+          git clone --single-branch -b 2.4.x https://github.com/snowdrop/testsuite.git
           cd testsuite
 
           echo "Setting testsuite parent version to ${parent_version}"
@@ -66,7 +66,7 @@ jobs:
           parent_version=$(mvn -s .circleci/settings.xml -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
 
           pushd /tmp
-          git clone --single-branch -b sb-2.3.x https://github.com/snowdrop/rest-http-example.git
+          git clone --single-branch -b sb-2.4.x https://github.com/snowdrop/rest-http-example.git
           cd rest-http-example
 
           echo "Setting rest-http-example parent version to ${parent_version}"


### PR DESCRIPTION
The circleci tests were still pointing to branches 2.3.x both in the example as well as in the testsuite project. This update fixes this.